### PR TITLE
Fix drain_from_back

### DIFF
--- a/src/sized_chunk.rs
+++ b/src/sized_chunk.rs
@@ -493,8 +493,8 @@ where
         debug_assert!(self_len + count <= N::USIZE);
         debug_assert!(other_len >= count);
         if self.left < count {
-            self.left = N::USIZE - self.right;
-            unsafe { Chunk::force_copy(0, self.left, self.right, self) };
+            unsafe { Chunk::force_copy(self.left, N::USIZE - self_len, self_len, self) };
+            self.left = N::USIZE - self_len;
             self.right = N::USIZE;
         }
         unsafe { Chunk::force_copy_to(other.right - count, self.left - count, count, other, self) };


### PR DESCRIPTION
In drain_from_back, we want to add elements to the front of the chunk. If there
is not enough space on the front/left side, then we first need to shift the data
to the right.

This commit makes sure that we shift that data to the very end of the chunk
and that the left offset is set to the chunk size minus length of the data,
in order to maintain that length = right - left.

Here is a program that exposes the issue (I used cargo fuzz to find it)
Let me know if I should submit a testcase.
```rust
        let mut x = im::Vector::new();
        for _ in 0..41 { x.push_front(0); }
        for _ in 0..34 { x.push_back(0); }
        for _ in 0..54 { x.insert(1, 0); }
        x.push_front(0);
        x.insert(1, 0);
        x.push_front(0);
        x.insert(1, 0);
        x.remove(0);
        x.remove(5);
        x.remove(0);
        x.insert(1, 0);
```