### PR TITLE
Use MaybeUninit instead of ManuallyDrop to inhibit the validity invariant of the storage type

### DIFF
--- a/src/inline_array.rs
+++ b/src/inline_array.rs
@@ -12,7 +12,7 @@ use std::fmt::{Debug, Error, Formatter};
 use std::hash::{Hash, Hasher};
 use std::iter::{FromIterator, FusedIterator};
 use std::marker::PhantomData;
-use std::mem::{self, ManuallyDrop};
+use std::mem::{self, MaybeUninit};
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 use std::slice::{from_raw_parts, from_raw_parts_mut, Iter as SliceIter, IterMut as SliceIterMut};
@@ -70,7 +70,7 @@ use std::slice::{from_raw_parts, from_raw_parts_mut, Iter as SliceIter, IterMut 
 /// Both of these will have the same size, and we can swap the `Inline` case out
 /// with the `Full` case once the `InlineArray` runs out of capacity.
 pub struct InlineArray<A, T> {
-    data: ManuallyDrop<T>,
+    data: MaybeUninit<T>,
     phantom: PhantomData<A>,
 }
 
@@ -153,7 +153,14 @@ impl<A, T> InlineArray<A, T> {
     #[must_use]
     pub fn new() -> Self {
         debug_assert!(Self::HOST_SIZE > Self::HEADER_SIZE);
-        unsafe { mem::zeroed() }
+        let mut self_ = Self {
+            data: MaybeUninit::uninit(),
+            phantom: PhantomData,
+        };
+        unsafe {
+            *self_.len_mut() = 0
+        }
+        self_
     }
 
     #[inline]

--- a/src/inline_array.rs
+++ b/src/inline_array.rs
@@ -267,10 +267,7 @@ impl<A, T> InlineArray<A, T> {
     #[inline]
     fn drop_contents(&mut self) {
         unsafe {
-            let data = self.data_mut();
-            for i in 0..self.len() {
-                ptr::drop_in_place(data.add(i));
-            }
+            ptr::drop_in_place::<[A]>(&mut **self)
         }
     }
 

--- a/src/sparse_chunk.rs
+++ b/src/sparse_chunk.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Error, Formatter};
-use std::mem::{self, ManuallyDrop};
+use std::mem::{self, MaybeUninit};
 use std::ops::Index;
 use std::ops::IndexMut;
 use std::ptr;
@@ -58,7 +58,7 @@ use crate::types::{Bits, ChunkLength};
 /// [Unsigned]: https://docs.rs/typenum/1.10.0/typenum/marker_traits/trait.Unsigned.html
 pub struct SparseChunk<A, N: Bits + ChunkLength<A> = U64> {
     map: Bitmap<N>,
-    data: ManuallyDrop<N::SizedType>,
+    data: MaybeUninit<N::SizedType>,
 }
 
 impl<A, N: Bits + ChunkLength<A>> Drop for SparseChunk<A, N> {
@@ -117,7 +117,10 @@ where
 
     /// Construct a new empty chunk.
     pub fn new() -> Self {
-        unsafe { mem::zeroed() }
+        Self {
+            map: Bitmap::default(),
+            data: MaybeUninit::uninit(),
+        }
     }
 
     /// Construct a new chunk with one item.

--- a/src/tests/inline_array.rs
+++ b/src/tests/inline_array.rs
@@ -7,6 +7,15 @@ use proptest_derive::Arbitrary;
 
 use crate::inline_array::InlineArray;
 
+#[test]
+fn validity_invariant() {
+    assert!(Some(InlineArray::<usize, [Box<()>; 2]>::new()).is_some());
+
+    let mut chunk = InlineArray::<usize, [Box<()>; 2]>::new();
+    chunk.push(0);
+    assert!(Some(chunk).is_some());
+}
+
 type TestType = [usize; 16];
 
 #[derive(Arbitrary, Debug)]

--- a/src/tests/ring_buffer.rs
+++ b/src/tests/ring_buffer.rs
@@ -9,6 +9,11 @@ use proptest_derive::Arbitrary;
 
 use crate::ring_buffer::RingBuffer;
 
+#[test]
+fn validity_invariant() {
+    assert!(Some(RingBuffer::<Box<()>>::new()).is_some());
+}
+
 #[derive(Debug)]
 struct InputVec<A>(Vec<A>);
 

--- a/src/tests/sized_chunk.rs
+++ b/src/tests/sized_chunk.rs
@@ -9,6 +9,11 @@ use proptest_derive::Arbitrary;
 
 use crate::sized_chunk::Chunk;
 
+#[test]
+fn validity_invariant() {
+    assert!(Some(Chunk::<Box<()>>::new()).is_some());
+}
+
 #[derive(Debug)]
 struct InputVec<A>(Vec<A>);
 

--- a/src/tests/sparse_chunk.rs
+++ b/src/tests/sparse_chunk.rs
@@ -9,6 +9,11 @@ use proptest_derive::Arbitrary;
 
 use crate::sparse_chunk::SparseChunk;
 
+#[test]
+fn validity_invariant() {
+    assert!(Some(SparseChunk::<Box<()>>::new()).is_some());
+}
+
 #[derive(Arbitrary, Debug)]
 enum Construct<A> {
     Empty,


### PR DESCRIPTION
This fixes the tests added in the first commit, which failed previously:

```rust
assertion failed: Some(InlineArray::<usize, [Box<()>; 2]>::new()).is_some()
assertion failed: Some(RingBuffer::<Box<()>>::new()).is_some()
assertion failed: Some(Chunk::<Box<()>>::new()).is_some()
assertion failed: Some(SparseChunk::<Box<()>>::new()).is_some()
```

`Box<_>` contains a pointer that is known not to be null, so `Option<Box<_>>` can be stored on a single pointer with null representing `None`. This also works for structs that contain a `Box` field, even within `ManuallyDrop`, so writing zero to that memory location is incorrect. With `MaybeUninit` however, it is correct for any byte of the memory representation to be zero (or not initialized) so the enum layout optimization does not use niches found within `MaybeUninit`.

----

Also some less important drive-by changes in the latter two commits, let me know if you’d prefer having them separately or not having them.