### PR TITLE
add Miri to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ matrix:
           install:
               - rustup component add clippy; true
           script: cargo clippy -- -D warnings
+        
+        - name: Miri
+          arch: amd64
+          rust: stable
+          script: ci/miri.sh
 
         - name: Coveralls
           arch: amd64

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
+rustup set profile minimal
+rustup default "$MIRI_NIGHTLY"
+
+rustup component add miri
+cargo miri setup
+
+cargo miri test

--- a/src/sparse_chunk/iter.rs
+++ b/src/sparse_chunk/iter.rs
@@ -165,7 +165,7 @@ impl<'a, A, N: Bits + ChunkLength<A>> Iterator for OptionDrain<A, N> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod test {
     use super::*;
     use proptest::{collection::vec, num::usize, option::of, prop_assert, proptest};


### PR DESCRIPTION
Proptests do not work yet, but we can test the rest, at least.

(Also, I locally verified that proptests will work once https://github.com/rust-lang/miri/pull/1243 lands. I need to set PROPTEST_CASES down, though.)