### PR TITLE
Remove bitmaps std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ std = []
 ringbuffer = ["array-ops"]
 
 [dependencies]
-bitmaps = "3.0.0"
+bitmaps = { version = "3.1.0", default-features = false } 
 array-ops = { version = "0.1.0", optional = true }
 refpool = { version = "0.4.3", optional = true }
 arbitrary = { version = "1.0.0", optional = true }


### PR DESCRIPTION
 This allows building to `thumbv8m.main-none-eabihf` on latest nightly.